### PR TITLE
Support PyPy. Closes zopefoundation/zodbpickle#10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 sudo: false
 python:
+    - pypy
     - 3.3
 install:
     - pip install . --use-mirrors

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@
 ##############################################################################
 """Setup"""
 import os
+import platform
 import sys
 
 from setuptools import Extension, find_packages, setup
@@ -28,6 +29,17 @@ elif sys.version_info[:2] == (3, 2):
     EXT = 'src/zodbpickle/_pickle_32.c'
 else:
     EXT = 'src/zodbpickle/_pickle_33.c'
+
+# PyPy won't build the extension.
+py_impl = getattr(platform, 'python_implementation', lambda: None)
+is_pypy = py_impl() == 'PyPy'
+is_pure = 'PURE_PYTHON' in os.environ
+if is_pypy or is_pure:
+    ext_modules = []
+else:
+    ext_modules = [Extension(name='zodbpickle._pickle',
+                             sources=[EXT])]
+
 
 setup(
     name='zodbpickle',
@@ -50,6 +62,7 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Framework :: ZODB',
         'Topic :: Database',
         'Topic :: Software Development :: Libraries :: Python Modules',
@@ -60,10 +73,7 @@ setup(
     platforms=['any'],
     packages=find_packages('src'),
     package_dir = {'':'src'},
-    ext_modules = [
-        Extension(name='zodbpickle._pickle',
-                  sources=[EXT])
-        ],
+    ext_modules = ext_modules,
     extras_require = {
         'test': (),
         'testing': ['nose', 'coverage'],

--- a/src/zodbpickle/tests/__init__.py
+++ b/src/zodbpickle/tests/__init__.py
@@ -1,1 +1,6 @@
-# Make a package.
+import os
+import platform
+
+py_impl = getattr(platform, 'python_implementation', lambda: None)
+_is_pypy = py_impl() == 'PyPy'
+_is_pure = 'PURE_PYTHON' in os.environ

--- a/src/zodbpickle/tests/pickletester_2.py
+++ b/src/zodbpickle/tests/pickletester_2.py
@@ -13,8 +13,16 @@ except ImportError:
     def precisionbigmemtest(*args, **kwargs):
         return lambda self: None
 
+from . import _is_pypy
+from . import _is_pure
 from zodbpickle import pickle_2 as pickle
-from zodbpickle import _pickle as cPickle
+try:
+    from zodbpickle import _pickle as cPickle
+    has_c_implementation = not _is_pypy and not _is_pure
+except ImportError:
+    cPickle = pickle
+    has_c_implementation = False
+
 from zodbpickle import pickletools_2 as pickletools
 
 # Tests that try a number of pickle protocols should have a
@@ -1169,6 +1177,8 @@ class AbstractPickleModuleTests(unittest.TestCase):
         s = StringIO.StringIO("X''.")
         self.assertRaises(EOFError, self.module.load, s)
 
+    @unittest.skipIf(_is_pypy,
+                     "Fails to access the redefined builtins")
     def test_restricted(self):
         # issue7128: cPickle failed in restricted mode
         builtins = {'pickleme': self.module,

--- a/src/zodbpickle/tests/test_pickle_2.py
+++ b/src/zodbpickle/tests/test_pickle_2.py
@@ -7,7 +7,8 @@ from .pickletester_2 import (AbstractPickleTests,
                              AbstractPickleModuleTests,
                              AbstractPersistentPicklerTests,
                              AbstractPicklerUnpicklerObjectTests,
-                             BigmemPickleTests)
+                             BigmemPickleTests,
+                             has_c_implementation)
 
 from test import test_support
 
@@ -340,27 +341,31 @@ class cPickleDeepRecursive(unittest.TestCase):
 
 def test_suite():
     import unittest
-    return unittest.TestSuite((
+    tests = [
         unittest.makeSuite(PickleTests),
         unittest.makeSuite(PicklerTests),
         unittest.makeSuite(PersPicklerTests),
         unittest.makeSuite(PicklerUnpicklerObjectTests),
         unittest.makeSuite(PickleBigmemPickleTests),
-        
-        unittest.makeSuite(cPickleTests),
-        unittest.makeSuite(cStringIOCPicklerTests),
-        unittest.makeSuite(BytesIOCPicklerTests),
-        unittest.makeSuite(FileIOCPicklerTests),        
-        unittest.makeSuite(cStringIOCPicklerListTests),
-        unittest.makeSuite(BytesIOCPicklerListTests),
-        unittest.makeSuite(FileIOCPicklerListTests),
-        unittest.makeSuite(cStringIOCPicklerFastTests),
-        unittest.makeSuite(BytesIOCPicklerFastTests),
-        unittest.makeSuite(FileIOCPicklerFastTests),
-        unittest.makeSuite(cPickleDeepRecursive),
-        unittest.makeSuite(cPicklePicklerUnpicklerObjectTests),
-        unittest.makeSuite(cPickleBigmemPickleTests),
-    ))
+	]
+
+    if has_c_implementation:
+        tests.extend([
+            unittest.makeSuite(cPickleTests),
+            unittest.makeSuite(cStringIOCPicklerTests),
+            unittest.makeSuite(BytesIOCPicklerTests),
+            unittest.makeSuite(FileIOCPicklerTests),
+            unittest.makeSuite(cStringIOCPicklerListTests),
+            unittest.makeSuite(BytesIOCPicklerListTests),
+            unittest.makeSuite(FileIOCPicklerListTests),
+            unittest.makeSuite(cStringIOCPicklerFastTests),
+            unittest.makeSuite(BytesIOCPicklerFastTests),
+            unittest.makeSuite(FileIOCPicklerFastTests),
+            unittest.makeSuite(cPickleDeepRecursive),
+            unittest.makeSuite(cPicklePicklerUnpicklerObjectTests),
+            unittest.makeSuite(cPickleBigmemPickleTests),
+        ])
+    return unittest.TestSuite(tests)
 
 if __name__ == '__main__':
     test_support.run_unittest(test_suite())

--- a/src/zodbpickle/tests/test_pickle_3.py
+++ b/src/zodbpickle/tests/test_pickle_3.py
@@ -3,6 +3,7 @@ import collections
 import unittest
 import doctest
 import sys
+from test import support as test_support
 
 from .pickletester_3 import AbstractPickleTests
 from .pickletester_3 import AbstractPickleModuleTests
@@ -13,11 +14,13 @@ from .pickletester_3 import BigmemPickleTests
 from .pickletester_3 import AbstractBytestrTests
 from .pickletester_3 import AbstractBytesFallbackTests
 
+from . import _is_pypy
+from . import _is_pure
 from zodbpickle import pickle_3 as pickle
 
 try:
     from zodbpickle import _pickle
-    has_c_implementation = True
+    has_c_implementation = not _is_pypy and not _is_pure
 except ImportError:
     has_c_implementation = False
 
@@ -170,3 +173,6 @@ def test_suite():
     ] + [
         doctest.DocTestSuite(pickle),
     ])
+
+if __name__ == '__main__':
+    test_support.run_unittest(test_suite())

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33
+envlist = py26,py27,py32,py33,pypy,pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
Supports installation and running under PyPy2 and PyPy3. 

As-is, the line `from zodbpickle import fastpickle` will fail with an `ImportError` under PyPy (the other uses cases work). It would be possible to make that fall back to `slowpickle`, but it could be argued that's slightly disingenuous since the user is explicitly requesting the non-existent C implementation. However, if desired I can add a commit to make that happen. 