### PR TITLE
Restore `noload` to its Python 2.6 functionality and provide it for PyPy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ parts
 *.so
 __pycache__
 *.pyc
+.dir-locals.el

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 ``zodbpickle`` Changelog
 ========================
 
+0.6.0 (unreleased)
+------------------
+
+- Add support for PyPy.
+
+- Restore the ``noload`` behaviour from Python 2.6 and provide the
+  ``noload`` method on the non-C-accelerated unpicklers under PyPy and
+  Python 2.
+
 0.5.2 (2013-08-17)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ else:
 
 setup(
     name='zodbpickle',
-    version='0.5.2',
+    version='0.6.0.dev0',
     description='Fork of Python 3 pickle module.',
     author='Python and Zope Foundation',
     author_email='zodb-dev@zope.org',

--- a/src/zodbpickle/tests/pickletester_2.py
+++ b/src/zodbpickle/tests/pickletester_2.py
@@ -1178,16 +1178,17 @@ class AbstractPickleModuleTests(unittest.TestCase):
         s = StringIO.StringIO("X''.")
         self.assertRaises(EOFError, self.module.load, s)
 
-    @unittest.skipIf(_is_pypy,
-                     "Fails to access the redefined builtins")
-    def test_restricted(self):
-        # issue7128: cPickle failed in restricted mode
-        builtins = {'pickleme': self.module,
-                    '__import__': __import__}
-        d = {}
-        teststr = "def f(): pickleme.dumps(0)"
-        exec teststr in {'__builtins__': builtins}, d
-        d['f']()
+    if not _is_pypy:
+        # PyPy cannot redefine the builtins;
+        # don't use unittest.skipIf because that's not in 2.6
+        def test_restricted(self):
+            # issue7128: cPickle failed in restricted mode
+            builtins = {'pickleme': self.module,
+                        '__import__': __import__}
+            d = {}
+            teststr = "def f(): pickleme.dumps(0)"
+            exec teststr in {'__builtins__': builtins}, d
+            d['f']()
 
     def test_bad_input(self):
         # Test issue4298

--- a/src/zodbpickle/tests/pickletester_2.py
+++ b/src/zodbpickle/tests/pickletester_2.py
@@ -1,3 +1,4 @@
+import io
 import unittest
 import StringIO
 import cStringIO
@@ -1233,6 +1234,17 @@ class AbstractPersistentPicklerTests(unittest.TestCase):
         self.assertEqual(self.id_count, 5)
         self.assertEqual(self.load_count, 5)
 
+
+REDUCE_A = 'reduce_A'
+
+class AAA(object):
+    def __reduce__(self):
+        return str, (REDUCE_A,)
+
+class BBB(object):
+    pass
+
+
 class AbstractPicklerUnpicklerObjectTests(unittest.TestCase):
 
     pickler_class = None
@@ -1345,6 +1357,124 @@ class AbstractPicklerUnpicklerObjectTests(unittest.TestCase):
         f.write(pickled2)
         f.seek(0)
         self.assertEqual(unpickler.load(), data2)
+
+    def test_noload_object(self):
+        global _NOLOAD_OBJECT
+        after = {}
+        _NOLOAD_OBJECT = object()
+        aaa = AAA()
+        bbb = BBB()
+        ccc = 1
+        ddd = 1.0
+        eee = ('eee', 1)
+        fff = ['fff']
+        ggg = {'ggg': 0}
+        unpickler = self.unpickler_class
+        f = io.BytesIO()
+        pickler = self.pickler_class(f, protocol=2)
+        pickler.dump(_NOLOAD_OBJECT)
+        after['_NOLOAD_OBJECT'] = f.tell()
+        pickler.dump(aaa)
+        after['aaa'] = f.tell()
+        pickler.dump(bbb)
+        after['bbb'] = f.tell()
+        pickler.dump(ccc)
+        after['ccc'] = f.tell()
+        pickler.dump(ddd)
+        after['ddd'] = f.tell()
+        pickler.dump(eee)
+        after['eee'] = f.tell()
+        pickler.dump(fff)
+        after['fff'] = f.tell()
+        pickler.dump(ggg)
+        after['ggg'] = f.tell()
+
+        f.seek(0)
+        unpickler = self.unpickler_class(f)
+        unpickler.noload() # read past _NOLOAD_OBJECT
+
+        self.assertEqual(f.tell(), after['_NOLOAD_OBJECT'])
+        noload = unpickler.noload() # read past aaa
+        self.assertEqual(noload, None)
+        self.assertEqual(f.tell(), after['aaa'])
+
+        unpickler.noload() # read past bbb
+        self.assertEqual(f.tell(), after['bbb'])
+
+        noload = unpickler.noload() # read past ccc
+        self.assertEqual(noload, ccc)
+        self.assertEqual(f.tell(), after['ccc'])
+
+        noload = unpickler.noload() # read past ddd
+        self.assertEqual(noload, ddd)
+        self.assertEqual(f.tell(), after['ddd'])
+
+        noload = unpickler.noload() # read past eee
+        self.assertEqual(noload, eee)
+        self.assertEqual(f.tell(), after['eee'])
+
+        noload = unpickler.noload() # read past fff
+        self.assertEqual(noload, fff)
+        self.assertEqual(f.tell(), after['fff'])
+
+        noload = unpickler.noload() # read past ggg
+        self.assertEqual(noload, ggg)
+        self.assertEqual(f.tell(), after['ggg'])
+
+    def test_functional_noload_dict_subclass(self):
+        """noload() doesn't break or produce any output given a dict subclass"""
+        # See http://bugs.python.org/issue1101399
+        o = MyDict()
+        o['x'] = 1
+        f = io.BytesIO()
+        pickler = self.pickler_class(f, protocol=2)
+        pickler.dump(o)
+        f.seek(0)
+        unpickler = self.unpickler_class(f)
+        noload = unpickler.noload()
+        self.assertEqual(noload, None)
+
+
+    def test_functional_noload_list_subclass(self):
+        """noload() doesn't break or produce any output given a list subclass"""
+        # See http://bugs.python.org/issue1101399
+        o = MyList()
+        o.append(1)
+        f = io.BytesIO()
+        pickler = self.pickler_class(f, protocol=2)
+        pickler.dump(o)
+        f.seek(0)
+        unpickler = self.unpickler_class(f)
+        noload = unpickler.noload()
+        self.assertEqual(noload, None)
+
+    def test_functional_noload_dict(self):
+        """noload() implements the Python 2.6 behaviour and fills in dicts"""
+        # See http://bugs.python.org/issue1101399
+        o = dict()
+        o['x'] = 1
+        f = io.BytesIO()
+        pickler = self.pickler_class(f, protocol=2)
+        pickler.dump(o)
+        f.seek(0)
+        unpickler = self.unpickler_class(f)
+        noload = unpickler.noload()
+        self.assertEqual(noload, o)
+
+
+    def test_functional_noload_list(self):
+        """noload() implements the Python 2.6 behaviour and fills in lists"""
+        # See http://bugs.python.org/issue1101399
+        o = list()
+        o.append(1)
+        f = io.BytesIO()
+        pickler = self.pickler_class(f, protocol=2)
+        pickler.dump(o)
+        f.seek(0)
+        unpickler = self.unpickler_class(f)
+        noload = unpickler.noload()
+        self.assertEqual(noload, o)
+
 
 class BigmemPickleTests(unittest.TestCase):
 

--- a/src/zodbpickle/tests/pickletester_3.py
+++ b/src/zodbpickle/tests/pickletester_3.py
@@ -1816,20 +1816,87 @@ class AbstractPicklerUnpicklerObjectTests(unittest.TestCase):
         unpickler = self.unpickler_class(f)
         unpickler.noload() # read past _NOLOAD_OBJECT
         self.assertEqual(f.tell(), after['_NOLOAD_OBJECT'])
-        unpickler.noload() # read past aaa
+
+        noload = unpickler.noload() # read past aaa
+        self.assertEqual(noload, None)
         self.assertEqual(f.tell(), after['aaa'])
+
         unpickler.noload() # read past bbb
         self.assertEqual(f.tell(), after['bbb'])
-        unpickler.noload() # read past ccc
+
+        noload = unpickler.noload() # read past ccc
+        self.assertEqual(noload, ccc)
         self.assertEqual(f.tell(), after['ccc'])
-        unpickler.noload() # read past ddd
+
+        noload = unpickler.noload() # read past ddd
+        self.assertEqual(noload, ddd)
         self.assertEqual(f.tell(), after['ddd'])
-        unpickler.noload() # read past eee
+
+        noload = unpickler.noload() # read past eee
+        self.assertEqual(noload, eee)
         self.assertEqual(f.tell(), after['eee'])
-        unpickler.noload() # read past fff
+
+        noload = unpickler.noload() # read past fff
+        self.assertEqual(noload, fff)
         self.assertEqual(f.tell(), after['fff'])
-        unpickler.noload() # read past ggg
+
+        noload = unpickler.noload() # read past ggg
+        self.assertEqual(noload, ggg)
         self.assertEqual(f.tell(), after['ggg'])
+
+    def test_functional_noload_dict_subclass(self):
+        """noload() doesn't break or produce any output given a dict subclass"""
+        # See http://bugs.python.org/issue1101399
+        o = MyDict()
+        o['x'] = 1
+        f = io.BytesIO()
+        pickler = self.pickler_class(f, protocol=2)
+        pickler.dump(o)
+        f.seek(0)
+        unpickler = self.unpickler_class(f)
+        noload = unpickler.noload()
+        self.assertEqual(noload, None)
+
+
+    def test_functional_noload_list_subclass(self):
+        """noload() doesn't break or produce any output given a list subclass"""
+        # See http://bugs.python.org/issue1101399
+        o = MyList()
+        o.append(1)
+        f = io.BytesIO()
+        pickler = self.pickler_class(f, protocol=2)
+        pickler.dump(o)
+        f.seek(0)
+        unpickler = self.unpickler_class(f)
+        noload = unpickler.noload()
+        self.assertEqual(noload, None)
+
+    def test_functional_noload_dict(self):
+        """noload() implements the Python 2.6 behaviour and fills in dicts"""
+        # See http://bugs.python.org/issue1101399
+        o = dict()
+        o['x'] = 1
+        f = io.BytesIO()
+        pickler = self.pickler_class(f, protocol=2)
+        pickler.dump(o)
+        f.seek(0)
+        unpickler = self.unpickler_class(f)
+        noload = unpickler.noload()
+        self.assertEqual(noload, o)
+
+
+    def test_functional_noload_list(self):
+        """noload() implements the Python 2.6 behaviour and fills in lists"""
+        # See http://bugs.python.org/issue1101399
+        o = list()
+        o.append(1)
+        f = io.BytesIO()
+        pickler = self.pickler_class(f, protocol=2)
+        pickler.dump(o)
+        f.seek(0)
+        unpickler = self.unpickler_class(f)
+        noload = unpickler.noload()
+        self.assertEqual(noload, o)
 
 
 # Tests for dispatch_table attribute


### PR DESCRIPTION
As described in #9, `noload` was broken by the fix to [Python bug 1101399]( http://bugs.python.org/issue1101399), which was merged into Python 2.7. This in turn breaks code such as `zc.zodbdgc`. 

This PR makes `noload` return to its 2.6 roots, but keeps the bug fix from upstream: intrinsic objects are loaded and populated, but subclasses of them are ignored.

Furthermore, because `noload` was only implemented in C for Python 2, it couldn't be used from PyPy, so it also adds `noload` to the Python implementation for Python 2.

The Python developers seem to consider 'noload' an undocumented extension, and it seems to be removed in Python 3 anyway, so to me it seems that diverging on the behaviour is probably okay.

I tested under Python 2.6, 2.7, 3.2 and 3.3, along with PyPy 2.5.1. (The tests are broken under Python 3.4, I'll try to submit another PR that adds support for 3.4 later.)