### PR TITLE
Fix tests under recent versions of Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: python
 sudo: false
 python:
     - pypy
+    - 2.6
+    - 2.7
+    - 3.2
     - 3.3
+    - 3.4
 install:
     - pip install . --use-mirrors
 script:

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Framework :: ZODB',

--- a/src/zodbpickle/tests/pickletester_2.py
+++ b/src/zodbpickle/tests/pickletester_2.py
@@ -1177,16 +1177,17 @@ class AbstractPickleModuleTests(unittest.TestCase):
         s = StringIO.StringIO("X''.")
         self.assertRaises(EOFError, self.module.load, s)
 
-    @unittest.skipIf(_is_pypy,
-                     "Fails to access the redefined builtins")
-    def test_restricted(self):
-        # issue7128: cPickle failed in restricted mode
-        builtins = {'pickleme': self.module,
-                    '__import__': __import__}
-        d = {}
-        teststr = "def f(): pickleme.dumps(0)"
-        exec teststr in {'__builtins__': builtins}, d
-        d['f']()
+    if not _is_pypy:
+        # PyPy cannot redefine the builtins;
+        # don't use unittest.skipIf because that's not in 2.6
+        def test_restricted(self):
+            # issue7128: cPickle failed in restricted mode
+            builtins = {'pickleme': self.module,
+                        '__import__': __import__}
+            d = {}
+            teststr = "def f(): pickleme.dumps(0)"
+            exec teststr in {'__builtins__': builtins}, d
+            d['f']()
 
     def test_bad_input(self):
         # Test issue4298

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,pypy,pypy3
+envlist = py26,py27,py32,py33,py34,pypy,pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
This doesn't support the new pickle protocol introduced in 3.4 (version 4), it just makes the existing tests run.

It also fixes the 2.6 failure introduced by #11, and adds all supported versions to be tested under travis.