### PR TITLE
Drop support for Python 2.6 and 3.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 sudo: false
 python:
-    - 2.6
     - 2.7
-    - 3.2
     - 3.3
     - 3.4
     - pypy
@@ -11,6 +9,6 @@ python:
 install:
     - pip install .
 script:
-    - python setup.py test -q
+    - python setup.py -q test -q
 notifications:
     email: false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,10 @@
 ``zodbpickle`` Changelog
 ========================
 
-0.6.1 (unreleased)
+0.7.0 (unreleased)
 ------------------
+
+- Drop support for Python 2.6 and 3.2.
 
 - Add support for Jython 2.7.
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ else:
 
 setup(
     name='zodbpickle',
-    version='0.6.1.dev0',
+    version='0.7.0.dev0',
     description='Fork of Python 3 pickle module.',
     author='Python and Zope Foundation',
     author_email='zodb-dev@zope.org',
@@ -57,10 +57,8 @@ setup(
         'License :: OSI Approved :: Python Software Foundation License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: Implementation :: CPython',

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 [tox]
 # Jython 2.7rc2 does work, but unfortunately has an issue running
 # with Tox 1.9.2 (http://bugs.jython.org/issue2325)
-envlist = py26,py27,py32,py33,py34,pypy,pypy3
+envlist = py27,py33,py34,pypy,pypy3
 
 [testenv]
 deps =
 commands =
-    python setup.py test -q
+    python setup.py -q test -q
 
 [testenv:jython]
 commands =
-   jython setup.py test -q
+   jython setup.py -q test -q
 
 [testenv:coverage]
 basepython =


### PR DESCRIPTION
- 2.6 is long out-of-maintenance, and a security quagmire.

- 3.2 cannot be tested on Travis.