### PR TITLE
Fix ZODB pickle corruption on python-3.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 1.0.4 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix pickle corruption under certain conditions. See `pull request 47
+  https://github.com/zopefoundation/zodbpickle/pull/47`_.
 
 
 1.0.3 (2018-12-18)

--- a/src/zodbpickle/_pickle_33.c
+++ b/src/zodbpickle/_pickle_33.c
@@ -736,7 +736,7 @@ _Pickler_Write(PicklerObject *self, const char *s, Py_ssize_t n)
                 PyErr_NoMemory();
                 return -1;
             }
-            self->max_output_len = (self->output_len + n) / 2 * 3;
+            self->max_output_len = (self->output_len + n) / 2 * 3 + 1;
             if (_PyBytes_Resize(&self->output_buffer, self->max_output_len) < 0)
                 return -1;
         }

--- a/src/zodbpickle/tests/pickletester_3.py
+++ b/src/zodbpickle/tests/pickletester_3.py
@@ -1272,6 +1272,29 @@ class AbstractPickleTests(unittest.TestCase):
             else:
                 self._check_pickling_with_opcode(obj, pickle.SETITEMS, proto)
 
+    def test_corrupted_pickle(self):
+        # Former C implementation produced corrupted pickles on these samples.
+        # See https://github.com/zopefoundation/zodbpickle/pull/47
+        sample1 = ['a'] * 17509
+        dumped = self.dumps(sample1, 0)
+        loaded = self.loads(dumped)
+        self.assertEqual(loaded, sample1)
+
+        sample2 = ['a'] * 34992
+        dumped = self.dumps(sample2, 1)
+        loaded = self.loads(dumped)
+        self.assertEqual(loaded, sample2)
+
+        sample3 = ['a'] * 34991
+        dumped = self.dumps(sample3, 2)
+        loaded = self.loads(dumped)
+        self.assertEqual(loaded, sample3)
+
+        sample4 = ['a'] * 34991
+        dumped = self.dumps(sample4, 3)
+        loaded = self.loads(dumped)
+        self.assertEqual(loaded, sample4)
+
 
 class AbstractBytestrTests(unittest.TestCase):
     def unpickleEqual(self, data, unpickled):


### PR DESCRIPTION
This is an attempt to fix a data corruption issue, that manifests in a
random byte replacing a correct one in a pickle, which makes a pickle unreadable.

I couldn't figure out the exact reason for it, but `max_output_len` in the fixed expression might become 0 under extreme conditions (when `output_len` is 0 and `n` is 1). The patch fixed the issue and was tested by our team for about a month.