### PR TITLE
Restructure Travis to always build manylinux wheels, enable Python 3.8 wheel builds

### DIFF
--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -5,10 +5,10 @@ set -e -x
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if [[ "${PYBIN}" == *"cp27"* ]] || \
-       [[ "${PYBIN}" == *"cp34"* ]] || \
        [[ "${PYBIN}" == *"cp35"* ]] || \
        [[ "${PYBIN}" == *"cp36"* ]] || \
-       [[ "${PYBIN}" == *"cp37"* ]]; then
+       [[ "${PYBIN}" == *"cp37"* ]] || \
+       [[ "${PYBIN}" == *"cp38"* ]]; then
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
         rm -rf /io/build /io/*.egg-info

--- a/.manylinux.sh
+++ b/.manylinux.sh
@@ -2,8 +2,4 @@
 
 set -e -x
 
-docker pull $DOCKER_IMAGE
-
-docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/.manylinux-install.sh
-
-pip install twine && twine upload -u zope.wheelbuilder -p $PYPIPASSWORD wheelhouse/*
+docker run --rm -v "$(pwd)":/io $DOCKER_IMAGE $PRE_CMD /io/.manylinux-install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,72 +1,88 @@
 language: python
-dist: xenial
-python:
-    - 2.7
-    - 3.5
-    - 3.6
-    - 3.7
-    - 3.8
-    - pypy
-    - pypy3
-matrix:
-    include:
-        # It's important to use 'macpython' builds to get the least
-        # restrictive wheel tag. It's also important to avoid
-        # 'homebrew 3' because it floats instead of being a specific version.
-        - os: osx
-          language: generic
-          env: TERRYFY_PYTHON='macpython 2.7'
-        - os: osx
-          language: generic
-          env: TERRYFY_PYTHON='macpython 3.4'
-        - os: osx
-          language: generic
-          env: TERRYFY_PYTHON='macpython 3.5'
-        - os: osx
-          language: generic
-          env: TERRYFY_PYTHON='macpython 3.6.1'
-        - os: osx
-          language: generic
-          env: TERRYFY_PYTHON='macpython 3.7.0'
-        - services:
-            - docker
-          env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
-          before_install:
-            - if [[ $TRAVIS_TAG ]]; then bash .manylinux.sh; fi
-            - exit 0
-        - services:
-            - docker
-          env:
-            - DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
-            - PRE_CMD=linux32
-          before_install:
-            - if [[ $TRAVIS_TAG ]]; then bash .manylinux.sh; fi
-            - exit 0
-before_install:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then git clone https://github.com/MacPython/terryfy; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source terryfy/travis_tools.sh; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then get_python_environment $TERRYFY_PYTHON venv; fi
-install:
-    - pip install -U pip setuptools
-    - pip install -U coveralls coverage
-    - pip install .
-script:
-    - coverage run setup.py test -q
-notifications:
-    email: false
-after_success:
-    - coveralls
-    - echo [distutils]                                  > ~/.pypirc
-    - echo index-servers = pypi                        >> ~/.pypirc
-    - echo [pypi]                                      >> ~/.pypirc
-    - echo username=zope.wheelbuilder                  >> ~/.pypirc
-    - echo password=$PYPIPASSWORD                      >> ~/.pypirc
-    - if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then pip install twine; fi
-    - if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then python setup.py bdist_wheel; fi
-    - if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then twine upload dist/*; fi
+
 env:
-    global:
-        secure: "edbJQIhe7grjaug7dxExoyB0zkrLca5IphzuQd2IfjGjBCY6Dn+QEBtDOMOcPjUsSvgxWL2XG2ZGIFF33bsoFlq0bZFPMtv5ZQ6jcpYQEpPX61fHsNzPs2RXavpHgHFC4aXt1o7jH7aSeImV98WWsNZTL5rhW4aHbgOM/jnnWdc="
+  global:
+    - TWINE_USERNAME: zope.wheelbuilder
+    # this sets $PYPIPASSWORD
+    - secure: "edbJQIhe7grjaug7dxExoyB0zkrLca5IphzuQd2IfjGjBCY6Dn+QEBtDOMOcPjUsSvgxWL2XG2ZGIFF33bsoFlq0bZFPMtv5ZQ6jcpYQEpPX61fHsNzPs2RXavpHgHFC4aXt1o7jH7aSeImV98WWsNZTL5rhW4aHbgOM/jnnWdc="
+
+python:
+  - 2.7
+  - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
+  - pypy
+  - pypy3
+
+jobs:
+  include:
+
+    # manylinux wheel builds
+    - name: 64-bit manylinux wheels (all Pythons)
+      services: docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+      install: docker pull $DOCKER_IMAGE
+      script: bash .manylinux.sh
+
+    - name: 32-bit manylinux wheels (all Pythons)
+      services: docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686 PRE_CMD=linux32
+      install: docker pull $DOCKER_IMAGE
+      script: bash .manylinux.sh
+
+    # It's important to use 'macpython' builds to get the least
+    # restrictive wheel tag. It's also important to avoid
+    # 'homebrew 3' because it floats instead of being a specific version.
+    - name: Python 2.7 wheels for MacOS
+      os: osx
+      language: generic
+      env: TERRYFY_PYTHON='macpython 2.7'
+    - name: Python 3.5 wheels for MacOS
+      os: osx
+      language: generic
+      env: TERRYFY_PYTHON='macpython 3.5'
+    - name: Python 3.6 wheels for MacOS
+      os: osx
+      language: generic
+      env: TERRYFY_PYTHON='macpython 3.6.1'
+    - name: Python 3.7 wheels for MacOS
+      os: osx
+      language: generic
+      env: TERRYFY_PYTHON='macpython 3.7.0'
+
+before_install:
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      git clone https://github.com/MacPython/terryfy
+      source terryfy/travis_tools.sh
+      get_python_environment $TERRYFY_PYTHON venv
+    fi
+
+install:
+  - pip install -U pip setuptools
+  - pip install -U coveralls coverage
+  - pip install .
+
+script:
+  - coverage run setup.py -q test
+
+after_success:
+  - coveralls
+  - |
+    if [[ $TRAVIS_TAG && "$TRAVIS_OS_NAME" == "osx" ]]; then
+      pip install twine
+      python setup.py bdist_wheel
+      TWINE_PASSWORD=$PYPIPASSWORD twine upload --skip-existing dist/*
+    fi
+  - |
+    if [[ $TRAVIS_TAG && -n "$DOCKER_IMAGE" ]]; then
+      pip install twine
+      TWINE_PASSWORD=$PYPIPASSWORD twine upload --skip-existing wheelhouse/*
+    fi
+
+notifications:
+  email: false
 
 cache: pip
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,18 @@ environment:
     - python: 36-x64
     - python: 37
     - python: 37-x64
+    - python: 38
+    - python: 38-x64
 
 install:
   - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
+  - ps: |
+      $env:PYTHON = "C:\\Python${env:PYTHON}"
+      if (-not (Test-Path $env:PYTHON)) {
+        curl -o install_python.ps1 https://raw.githubusercontent.com/matthew-brett/multibuild/11a389d78892cf90addac8f69433d5e22bfa422a/install_python.ps1
+        .\install_python.ps1
+      }
+  - ps: if (-not (Test-Path $env:PYTHON)) { throw "No $env:PYTHON" }
   - echo "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 > "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"
   - pip install -e .
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ build_script:
   - python -W ignore setup.py -q bdist_wheel
 
 test_script:
-  - python setup.py test -q
+  - python setup.py -q test
 
 artifacts:
   - path: 'dist\*.whl'

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,6 @@ setup(
     ext_modules=ext_modules,
     extras_require={
         'test': [],
-        'testing': ['nose', 'coverage'],
     },
     test_suite='zodbpickle.tests.test_pickle.test_suite',
     install_requires=[

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,8 @@ envlist = py27,py35,py36,py37,py38,pypy,pypy3,coverage-report
 [testenv]
 usedevelop = True
 commands =
-    coverage run setup.py test -q
+    coverage run setup.py -q test
 deps =
-    .
     coverage
 setenv =
     COVERAGE_FILE=.coverage.{envname}


### PR DESCRIPTION
### Highlights

- Enable Python 3.8 builds on Appveyor
- Enable Python 3.8 builds of manylinux wheels (and also drop 3.4)
- Try manylinux builds on every commit so we can discover breakages in advance
- No Python 3.8 on terryfy yet, so no Mac OS builds
- Add pretty names to Travis build matrix rows

### Details

The diff is messy, for which I apologize. I had to reformat the YAML to understand it.

Drop dist: xenial which has become the default.

Rename matrix: to jobs: because that's the preferred spelling according to Travis CI docs.

Move docker pull and twine upload out of .manylinux.sh and into .travis.yml.  (The docker pull mostly because we need to override the `install:` step and keeping it blank looks bad, and we need to override the step because we can no longer do an `exit 0` in `before_install` because we want to do the twine upload in `after_success`)

Unify twine upload calls by supplying username/password via environment variables.

The changes largely mirror those in https://github.com/zopefoundation/BTrees/pull/115.

There are also some minor cleanups in the way we run tests (e.g. -q needs to go between `python setup.py` and `test `, not at the end; dep = . in a tox.ini is pointless, and nose is deprecated upstream.)

Fixes #50.