### PR TITLE
Implement zodbpickle.binary in C for Py27.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,11 +2,14 @@
  Changelog
 ===========
 
-1.1.1 (unreleased)
+2.0.0 (unreleased)
 ==================
 
-- Nothing changed yet.
-
+- CPython 2: Make ``zodbpickle.binary`` objects smaller and untracked
+  by the garbage collector. Now they behave more like the native bytes
+  object. Just like it, and just like on Python 3, they cannot have
+  arbitrary attributes or be weakly referenced. See `issue 53
+  <https://github.com/zopefoundation/zodbpickle/issues/53>`_.
 
 1.1 (2019-11-09)
 ================

--- a/src/zodbpickle/__init__.py
+++ b/src/zodbpickle/__init__.py
@@ -1,11 +1,24 @@
 import sys
 
-if sys.version_info[0] < 3:
-    class binary(bytes):
-        """Mark a given string as explicitly binary
+__all__ = [
+    'binary',
+]
 
-        I.e., it should be unpickled as bytes on Py3k, rather than being
+if sys.version_info[0] < 3:
+    try:
+        from zodbpickle._pickle import binary
+    except ImportError:
+        # we get ImportError if the module isn't around at all,
+        # e.g., on PyPy. We get AttributeError if it doesn't define
+        # the binary attribute, which would be the case if we have an
+        # old version of the C extension library. That might happen in
+        # development but shouldn't in production; let it raise.
+        class binary(bytes):
+            """Mark a given string as explicitly binary
+
+            I.e., it should be unpickled as bytes on Py3k, rather than being
             forcibly promoted to unicode.
-        """
+            """
+            __slots__ = ()
 else:
     binary = bytes

--- a/src/zodbpickle/_pickle_27.c
+++ b/src/zodbpickle/_pickle_27.c
@@ -177,7 +177,10 @@ static PyTypeObject BinaryType_t = {
     0,                          /* tp_methods */
     0,                          /* tp_members */
     0,                          /* tp_getset */
-    &PyString_Type,             /* tp_base */
+    /* The Windows compiler compalins that this is not a constant. */
+    /* So initialize later. */
+    /* &PyString_Type, */       /* tp_base */
+    0,                          /* tp_base */
     0,                          /* tp_dict */
     0,                          /* tp_descr_get */
     0,                          /* tp_descr_set */
@@ -6223,6 +6226,7 @@ init_stuff(PyObject *module_dict)
         return -1;
     BinaryType_t.tp_basicsize = PyString_Type.tp_basicsize;
     BinaryType_t.tp_itemsize = PyString_Type.tp_itemsize;
+    BinaryType_t.tp_base = &PyString_Type;
     if (PyType_Ready(&BinaryType_t) < 0)
         return -1;
 

--- a/src/zodbpickle/_pickle_27.c
+++ b/src/zodbpickle/_pickle_27.c
@@ -118,7 +118,6 @@ static PyObject *PicklingError;
 static PyObject *UnpickleableError;
 static PyObject *UnpicklingError;
 static PyObject *BadPickleGet;
-static PyObject *BinaryType;  /* from zodbpickle import binary */
 
 /* As the name says, an empty tuple. */
 static PyObject *empty_tuple;
@@ -143,6 +142,53 @@ static PyObject *__class___str, *__getinitargs___str, *__dict___str,
   *write_str, *append_str,
   *read_str, *readline_str, *__main___str,
   *dispatch_table_str;
+
+static PyTypeObject BinaryType_t = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "zodbpickle.binary",        /* tp_name */
+    /* the sizes are filled in from PyString_Type later */
+    0,                          /* tp_basicsize */
+    0,                          /* tp_itemsize */
+    0,                          /* tp_dealloc */
+    0,                          /* tp_print */
+    0,                          /* tp_getattr */
+    0,                          /* tp_setattr */
+    0,                          /* tp_compare */
+    0,                          /* tp_repr */
+    0,                          /* tp_as_number */
+    0,                          /* tp_as_sequence */
+    0,                          /* tp_as_mapping */
+    0,                          /* tp_hash */
+    0,                          /* tp_call */
+    0,                          /* tp_str */
+    0,                          /* tp_getattro */
+    0,                          /* tp_setattro */
+    0,                          /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_CHECKTYPES |
+        Py_TPFLAGS_BASETYPE | Py_TPFLAGS_STRING_SUBCLASS |
+        Py_TPFLAGS_HAVE_NEWBUFFER,
+    NULL,                       /* tp_doc */
+    0,                          /* tp_traverse */
+    0,                          /* tp_clear */
+    0,                          /* tp_richcompare */
+    0,                          /* tp_weaklistoffset */
+    0,                          /* tp_iter */
+    0,                          /* tp_iternext */
+    0,                          /* tp_methods */
+    0,                          /* tp_members */
+    0,                          /* tp_getset */
+    &PyString_Type,             /* tp_base */
+    0,                          /* tp_dict */
+    0,                          /* tp_descr_get */
+    0,                          /* tp_descr_set */
+    0,                          /* tp_dictoffset */
+    0,                          /* tp_init */
+    0,                          /* tp_alloc */
+    0,                          /* tp_new */
+    0,                          /* tp_free */
+};
+
+static PyObject* BinaryType = (PyObject*)&BinaryType_t;
 
 /*************************************************************************
  Internal Data type for pickle data.                                     */
@@ -2716,10 +2762,6 @@ save(Picklerobject *self, PyObject *args, int pers_save)
 
     switch (type->tp_name[0]) {
     case 'b':
-        if (strcmp(type->tp_name, "binary") == 0) {
-            res = save_bytes(self, args);
-            goto finally;
-        }
         if (args == Py_False || args == Py_True) {
             res = save_bool(self, args);
             goto finally;
@@ -2768,6 +2810,14 @@ save(Picklerobject *self, PyObject *args, int pers_save)
         }
         break;
 #endif
+    case 'z':
+	/* No need to also support plain 'binary' as we would get from a type
+	   defined in Python; if we're running then our C BinaryType should be
+	   in use. */
+        if (strcmp(type->tp_name, "zodbpickle.binary") == 0) {
+            res = save_bytes(self, args);
+            goto finally;
+        }
     }
 
     if (Py_REFCNT(args) > 1) {
@@ -6159,6 +6209,7 @@ static struct PyMethodDef cPickle_methods[] = {
   { NULL, NULL }
 };
 
+
 static int
 init_stuff(PyObject *module_dict)
 {
@@ -6169,6 +6220,10 @@ init_stuff(PyObject *module_dict)
     if (PyType_Ready(&Unpicklertype) < 0)
         return -1;
     if (PyType_Ready(&Picklertype) < 0)
+        return -1;
+    BinaryType_t.tp_basicsize = PyString_Type.tp_basicsize;
+    BinaryType_t.tp_itemsize = PyString_Type.tp_itemsize;
+    if (PyType_Ready(&BinaryType_t) < 0)
         return -1;
 
     INIT_STR(__class__);
@@ -6288,6 +6343,10 @@ init_stuff(PyObject *module_dict)
                              BadPickleGet) < 0)
         return -1;
 
+    if (PyDict_SetItemString(module_dict, "binary",
+                             BinaryType) < 0)
+        return -1;
+
     PycString_IMPORT;
 
     return 0;
@@ -6308,6 +6367,7 @@ init_pickle(void)
     Py_TYPE(&Picklertype) = &PyType_Type;
     Py_TYPE(&Unpicklertype) = &PyType_Type;
     Py_TYPE(&PdataType) = &PyType_Type;
+    Py_TYPE(&BinaryType_t) = &PyType_Type;
 
     /* Initialize some pieces. We need to do this before module creation,
      * so we're forced to use a temporary dictionary. :(
@@ -6341,18 +6401,6 @@ init_pickle(void)
     i = PyModule_AddIntConstant(m, "HIGHEST_PROTOCOL", HIGHEST_PROTOCOL);
     if (i < 0)
         return;
-
-    if (BinaryType == NULL) {
-        PyObject *zodbpickle_module = PyImport_ImportModule("zodbpickle");
-        if (zodbpickle_module == NULL) {
-            return;
-        }
-        BinaryType = PyObject_GetAttrString(zodbpickle_module, "binary");
-        Py_DECREF(zodbpickle_module);
-        if (BinaryType == NULL) {
-            return;
-        }
-    }
 
     /* These are purely informational; no code uses them. */
     /* File format version we write. */

--- a/src/zodbpickle/tests/test_pickle_2.py
+++ b/src/zodbpickle/tests/test_pickle_2.py
@@ -339,14 +339,54 @@ class cPickleDeepRecursive(unittest.TestCase):
         _pickle.dumps(res)
 
 
+class BinaryTests(unittest.TestCase):
+
+    def test_has_no_attrs(self):
+        from zodbpickle import binary
+        b = binary('abc')
+        with self.assertRaises(AttributeError):
+            setattr(b, 'attr', 42)
+
+    def test_can_subclass(self):
+        from zodbpickle import binary
+        class MyBinary(binary):
+            pass
+
+        my = MyBinary('')
+        my.attr = 42
+        self.assertEqual(my, '')
+        self.assertEqual(my.attr, 42)
+
+class cBinaryTests(unittest.TestCase):
+
+    def test_same_size(self):
+        # PyPy doesn't support sys.getsizeof, but
+        # we don't run these tests there.
+        import sys
+        from zodbpickle import binary
+
+        s = b'abcdef'
+        b = binary(s)
+        self.assertEqual(sys.getsizeof(b), sys.getsizeof(s))
+
+    def test_not_tracked_by_gc(self):
+        # PyPy doesn't have gc.is_tracked, but we don't
+        # run these tests there.
+        import gc
+        from zodbpickle import binary
+        s = b'abcdef'
+        b = binary(s)
+        self.assertFalse(gc.is_tracked(s))
+        self.assertFalse(gc.is_tracked(b))
+
 def test_suite():
-    import unittest
     tests = [
         unittest.makeSuite(PickleTests),
         unittest.makeSuite(PicklerTests),
         unittest.makeSuite(PersPicklerTests),
         unittest.makeSuite(PicklerUnpicklerObjectTests),
         unittest.makeSuite(PickleBigmemPickleTests),
+        unittest.makeSuite(BinaryTests),
 	]
 
     if has_c_implementation:
@@ -364,6 +404,7 @@ def test_suite():
             unittest.makeSuite(cPickleDeepRecursive),
             unittest.makeSuite(cPicklePicklerUnpicklerObjectTests),
             unittest.makeSuite(cPickleBigmemPickleTests),
+            unittest.makeSuite(cBinaryTests),
         ])
     return unittest.TestSuite(tests)
 


### PR DESCRIPTION
Fixes #53

Makes the size the same as `str`:
```console
$ python -c 'import sys, zodbpickle; print(sys.getsizeof(("")))'
37
$ python -c 'import sys, zodbpickle; print(sys.getsizeof(zodbpickle.binary("")))'
37
```

And removes the GC overhead:
```
$ python -m pyperf timeit \
    -s "from zodbpickle import binary; strs = [binary(i) for i in range(1141836)]; import gc" \
     "gc.collect()"
.....................
Mean +- std dev: 10.2 ms +- 0.4 ms
```

It's no longer possible to set arbitrary attributes on a `binary` object, but it wasn't possible to do that on Python 3 so I don't think that's a big deal. Still, it's an incompatibility and I bumped to 2.0.

ZODB and RelStorage's test suites run without problems. I'm sure this is in one of the test cases somewhere, but I also manually verified that the pickles match before/after this change.

I will freely admit that I don't have a full and complete understanding of exactly all the ways that the various type fields interact, get inherited, impact flags, etc. I checked the important ones and this all seems reasonable but I'm very open to suggestions.