### PR TITLE
Support py3.9 and above.

### DIFF
--- a/src/zodbpickle/tests/pickletester_3.py
+++ b/src/zodbpickle/tests/pickletester_3.py
@@ -11,7 +11,12 @@ from test.support import (
     TestFailed, run_with_locale,
     _2G, _4G, bigmemtest,
     )
-from test.support.os_helper import TESTFN
+
+try:
+    from test.support import TESTFN
+except ImportError:
+    # changed import path in 3.10
+    from test.support.os_helper import TESTFN
 
 try:
     from test.support import no_tracing

--- a/src/zodbpickle/tests/pickletester_3.py
+++ b/src/zodbpickle/tests/pickletester_3.py
@@ -8,9 +8,10 @@ from zodbpickle import pickle_3 as pickle
 from zodbpickle import pickletools_3 as pickletools
 
 from test.support import (
-    TestFailed, TESTFN, run_with_locale,
+    TestFailed, run_with_locale,
     _2G, _4G, bigmemtest,
     )
+from test.support.os_helper import TESTFN
 
 try:
     from test.support import no_tracing


### PR DESCRIPTION
I'd really like to add this as something between a comment on an issue and a pull request as my C skills are quite rusty and although it builds and all the tests pass it should really be looked over closely.

The changes for _PyObject_LookupAttrId came from here: https://github.com/python/cpython/commit/98c4433a81a4cd88c7438adbee1f2aa486188ca3

Py_Size(x) = y to Py_SET_SIZE(x, y) and  _PyObject_HasAttrId to _PyObject_LookupAttrId