### PR TITLE
Use Py_SET_SIZE() in _pickle_33.c

### DIFF
--- a/src/zodbpickle/_pickle_33.c
+++ b/src/zodbpickle/_pickle_33.c
@@ -269,7 +269,8 @@ Pdata_pop(Pdata *self)
         PyErr_SetString(UnpicklingError, "bad pickle data");
         return NULL;
     }
-    return self->data[--Py_SIZE(self)];
+    Py_SET_SIZE(self, Py_SIZE(self) - 1);
+    return self->data[Py_SIZE(self)];
 }
 #define PDATA_POP(D, V) do { (V) = Pdata_pop((D)); } while (0)
 
@@ -279,7 +280,8 @@ Pdata_push(Pdata *self, PyObject *obj)
     if (Py_SIZE(self) == self->allocated && Pdata_grow(self) < 0) {
         return -1;
     }
-    self->data[Py_SIZE(self)++] = obj;
+    self->data[Py_SIZE(self)] = obj;
+    Py_SET_SIZE(self, Py_SIZE(self) + 1);
     return 0;
 }
 


### PR DESCRIPTION
Use Python 3.9 Py_SET_SIZE() function to set an object size. Add a
Py_SET_SIZE() implementation for Python 3.8 and older.

On Python 3.11, Py_SIZE() can no longer be used as an l-value to set
an object size:

* https://docs.python.org/dev/c-api/structures.html#c.Py_SIZE
* https://docs.python.org/dev/whatsnew/3.11.html#id2

Use the Py_REFCNT() and Py_TYPE() macros rather than accessing
directly to ob_refcnt and ob_type members of the  PyObject structure.