### PR TITLE
Add support for Python 3.11.0a7.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-alpha.4"
+          - "3.11.0-alpha.7"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -153,7 +153,7 @@ jobs:
           python setup.py bdist_wheel
           # Also install it, so that we get dependencies in the (pip) cache.
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
-          pip install .[test]
+          pip install --pre .[test]
 
       - name: Check zodbpickle build
         run: |
@@ -173,7 +173,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-          && !startsWith(matrix.python-version, '3.11.0-alpha.4')
+          && !startsWith(matrix.python-version, '3.11.0-alpha.7')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -195,7 +195,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-alpha.4"
+          - "3.11.0-alpha.7"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -247,7 +247,7 @@ jobs:
           # when we ask it to load tests from that directory. This
           # might also save some build time?
           unzip -n dist/zodbpickle-*whl -d src
-          pip install -U -e .[test]
+          pip install --pre -U -e .[test]
       - name: Run tests with C extensions
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,23 +95,24 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 2.7
-          - 3.5
-          - pypy-2.7
-          - pypy-3.6
-          - 3.6
-          - 3.7
-          - 3.8
-          - 3.9
-          - 3.10.0-rc.2
+          - "2.7"
+          - "3.5"
+          - "pypy-2.7"
+          - "pypy-3.7"
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11.0-alpha.4"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
-            python-version: pypy-2.7
+            python-version: "pypy-2.7"
           - os: macos-latest
-            python-version: pypy-3.6
+            python-version: "pypy-3.7"
           - os: macos-latest
-            python-version: 3.5
+            python-version: "3.5"
 
     steps:
       - name: checkout
@@ -143,7 +144,6 @@ jobs:
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi
-          pip install -U coveralls coverage
 
       - name: Build zodbpickle
         run: |
@@ -152,7 +152,6 @@ jobs:
           python setup.py build_ext -i
           python setup.py bdist_wheel
           # Also install it, so that we get dependencies in the (pip) cache.
-          pip install -U coverage
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
           pip install .[test]
 
@@ -169,7 +168,12 @@ jobs:
         # We cannot 'uses: pypa/gh-action-pypi-publish@v1.4.1' because
         # that's apparently a container action, and those don't run on
         # the Mac.
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && startsWith(runner.os, 'Mac')
+        if: >
+          github.event_name == 'push'
+          && startsWith(github.ref, 'refs/tags')
+          && startsWith(runner.os, 'Mac')
+          && !startsWith(matrix.python-version, 'pypy')
+          && !startsWith(matrix.python-version, '3.11.0-alpha.4')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -182,23 +186,24 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 2.7
-          - 3.5
-          - pypy-2.7
-          - pypy-3.6
-          - 3.6
-          - 3.7
-          - 3.8
-          - 3.9
-          - 3.10.0-rc.2
+          - "2.7"
+          - "3.5"
+          - "pypy-2.7"
+          - "pypy-3.7"
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11.0-alpha.4"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
-            python-version: pypy-2.7
+            python-version: "pypy-2.7"
           - os: macos-latest
-            python-version: pypy-3.6
+            python-version: "pypy-3.7"
           - os: macos-latest
-            python-version: 3.5
+            python-version: "3.5"
 
     steps:
       - name: checkout
@@ -234,7 +239,9 @@ jobs:
       - name: Install zodbpickle
         run: |
           pip install -U wheel setuptools
-          pip install -U coverage coverage-python-version
+          # coverage has a wheel on PyPI for a future python version which is
+          # not ABI compatible with the current one, so build it from sdist:
+          pip install -U --no-binary :all: coverage
           pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
@@ -273,7 +280,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ["3.9"]
         os: [ubuntu-20.04]
 
     steps:
@@ -325,7 +332,7 @@ jobs:
     # We use a regular Python matrix entry to share as much code as possible.
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ["3.9"]
         image: [manylinux2010_x86_64, manylinux2010_i686, manylinux2014_aarch64]
 
     steps:
@@ -392,7 +399,9 @@ jobs:
         run: sudo chown -R $(whoami) ${{ steps.pip-cache.outputs.dir }}
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@v1.4.1
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: >
+          github.event_name == 'push'
+          && startsWith(github.ref, 'refs/tags')
         with:
           user: __token__
           password: ${{ secrets.TWINE_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ lib64
 log/
 parts/
 pyvenv.cfg
+testing.log
 var/

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -28,13 +28,15 @@ yum -y install libffi-devel
 
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
-    if [[ "${PYBIN}" == *"cp27"* ]] || \
+    if \
+       [[ "${PYBIN}" == *"cp27"* ]] || \
        [[ "${PYBIN}" == *"cp35"* ]] || \
+       [[ "${PYBIN}" == *"cp311"* ]] || \
        [[ "${PYBIN}" == *"cp36"* ]] || \
        [[ "${PYBIN}" == *"cp37"* ]] || \
        [[ "${PYBIN}" == *"cp38"* ]] || \
-       [[ "${PYBIN}" == *"cp310"* ]] || \
-       [[ "${PYBIN}" == *"cp39"* ]]; then
+       [[ "${PYBIN}" == *"cp39"* ]] || \
+       [[ "${PYBIN}" == *"cp310"* ]] ; then
         "${PYBIN}/pip" install -e /io/
         "${PYBIN}/pip" wheel /io/ -w wheelhouse/
         if [ `uname -m` == 'aarch64' ]; then

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "15807bd13de45b79c7da560a377fe3f22cbc4338"
+commit-id = "ab709c2e22dff33a005b4237df8a2e0b6baf2f7b"
 
 [python]
 with-appveyor = true
@@ -10,7 +10,7 @@ with-windows = false
 with-pypy = true
 with-legacy-python = true
 with-sphinx-doctests = false
-with-future-python = false
+with-future-python = true
 
 [tox]
 use-flake8 = false

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "5b60e8235223c5c73427d4cdf66be5fb2cce3cea"
+commit-id = "45b1f148eda3f6f46bde852104f8e06c4b3df267"
 
 [python]
 with-appveyor = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 2.2.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Add support for Python 3.11 (as of 3.11.0a4).
 
 
 2.2.0 (2021-09-29)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 2.2.1 (unreleased)
 ==================
 
-- Add support for Python 3.11 (as of 3.11.0a4).
+- Add support for Python 3.11 (as of 3.11.0a7).
 
 
 2.2.0 (2021-09-29)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,10 +21,12 @@ environment:
     - python: 38-x64
     - python: 39
     - python: 39-x64
+    - python: 310
+    - python: 310-x64
     # `multibuild` cannot install non-final versions as they are not on
-    # ftp.python.org, so we skip Python 3.10 until its final release:
-    # - python: 310
-    # - python: 310-x64
+    # ftp.python.org, so we skip Python 3.11 until its final release:
+    # - python: 311
+    # - python: 311-x64
 
 install:
   - "SET PYTHONVERSION=%PYTHON%"

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,3 +25,14 @@ per-file-ignores =
 ignore =
     .editorconfig
     .meta.toml
+
+[isort]
+force_single_line = True
+combine_as_imports = True
+sections = FUTURE,STDLIB,THIRDPARTY,ZOPE,FIRSTPARTY,LOCALFOLDER
+known_third_party = six, docutils, pkg_resources
+known_zope =
+known_first_party =
+default_section = ZOPE
+line_length = 79
+lines_after_imports = 2

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ envlist =
 
 [testenv]
 usedevelop = true
+pip_pre = true
 deps =
 setenv =
     pure: PURE_PYTHON=1
@@ -49,10 +50,10 @@ commands =
 [testenv:lint]
 basepython = python3
 skip_install = true
+commands =
+    check-manifest
+    check-python-versions
 deps =
     check-manifest
     check-python-versions >= 0.19.1
     wheel
-commands =
-    check-manifest
-    check-python-versions

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
     py38,py38-pure
     py39,py39-pure
     py310,py310-pure
+    py311,py311-pure
     pypy
     pypy3
     coverage
@@ -50,7 +51,7 @@ basepython = python3
 skip_install = true
 deps =
     check-manifest
-    check-python-versions
+    check-python-versions >= 0.19.1
     wheel
 commands =
     check-manifest


### PR DESCRIPTION
To run successfully the following changes are required:

- [x] ~~merge of https://github.com/zopefoundation/zodbpickle/pull/64~~
- [x] recreate the changes made in https://github.com/zopefoundation/zodbpickle/pull/64
- [x] fix of https://github.com/zopefoundation/zodbpickle/pull/64#issuecomment-1025719735 see #67 for the solution 
- [x] GHA must provide Python 3.11.0a7.

Fixes #67.
