### PR TITLE
Preliminary support for Python 3.13a5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,6 +103,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13.0-alpha - 3.13.0"
         os: [ubuntu-20.04, macos-11]
         exclude:
           - os: macos-11
@@ -134,7 +135,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      - name: Install Build Dependencies (3.13.0-alpha - 3.13.0)
+        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
+        run: |
+          pip install -U pip
+          pip install -U setuptools wheel twine
+          # cffi will probably have no public release until a Python 3.13 beta
+          # or even RC release, see https://github.com/python-cffi/cffi/issues/23
+          echo "cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58" > cffi_constraint.txt
+          PIP_CONSTRAINT=$PWD/cffi_constraint.txt pip install cffi
       - name: Install Build Dependencies
+        if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi
@@ -178,7 +189,18 @@ jobs:
           python setup.py build_ext -i
           python setup.py bdist_wheel
 
+      - name: Install zodbpickle and dependencies (3.13.0-alpha - 3.13.0)
+        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
+        run: |
+          # Install to collect dependencies into the (pip) cache.
+          # cffi will probably have no public release until a Python 3.13 beta
+          # or even RC release, see https://github.com/python-cffi/cffi/issues/23
+          echo "cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58" > cffi_constraint.txt
+          # Use "--pre" here because dependencies with support for this future
+          # Python release may only be available as pre-releases
+          PIP_CONSTRAINT=$PWD/cffi_constraint.txt pip install --pre .[test]
       - name: Install zodbpickle and dependencies
+        if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
           # Install to collect dependencies into the (pip) cache.
           pip install .[test]
@@ -222,6 +244,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
+          && !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -241,6 +264,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13.0-alpha - 3.13.0"
         os: [ubuntu-20.04, macos-11]
         exclude:
           - os: macos-11
@@ -277,7 +301,25 @@ jobs:
         with:
           name: zodbpickle-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
+      - name: Install zodbpickle 3.13.0-alpha - 3.13.0
+        if: ${{ startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
+        run: |
+          pip install -U wheel setuptools
+          # cffi will probably have no public release until a beta or even RC
+          # version of Python 3.13, see https://github.com/python-cffi/cffi/issues/23
+          echo 'cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58 ; platform_python_implementation == "CPython"' > cffi_constraint.txt
+          # coverage has a wheel on PyPI for a future python version which is
+          # not ABI compatible with the current one, so build it from sdist:
+          pip install -U --no-binary :all: coverage
+          # Unzip into src/ so that testrunner can find the .so files
+          # when we ask it to load tests from that directory. This
+          # might also save some build time?
+          unzip -n dist/zodbpickle-*whl -d src
+          # Use "--pre" here because dependencies with support for this future
+          # Python release may only be available as pre-releases
+          PIP_CONSTRAINT=$PWD/cffi_constraint.txt pip install --pre -U -e .[test]
       - name: Install zodbpickle
+        if: ${{ !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
         run: |
           pip install -U wheel setuptools
           pip install -U coverage

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -28,6 +28,7 @@ yum -y install libffi-devel
 
 tox_env_map() {
     case $1 in
+        *"cp313"*) echo 'py313';;
         *"cp37"*) echo 'py37';;
         *"cp38"*) echo 'py38';;
         *"cp39"*) echo 'py39';;
@@ -41,14 +42,20 @@ tox_env_map() {
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if \
+       [[ "${PYBIN}" == *"cp313"* ]] || \
        [[ "${PYBIN}" == *"cp311"* ]] || \
        [[ "${PYBIN}" == *"cp312"* ]] || \
        [[ "${PYBIN}" == *"cp37"* ]] || \
        [[ "${PYBIN}" == *"cp38"* ]] || \
        [[ "${PYBIN}" == *"cp39"* ]] || \
        [[ "${PYBIN}" == *"cp310"* ]] ; then
-        "${PYBIN}/pip" install -e /io/
-        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+        if [[ "${PYBIN}" == *"cp313"* ]] ; then
+            "${PYBIN}/pip" install --pre -e /io/
+            "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
+        else
+            "${PYBIN}/pip" install -e /io/
+            "${PYBIN}/pip" wheel /io/ -w wheelhouse/
+        fi
         if [ `uname -m` == 'aarch64' ]; then
           cd /io/
           ${PYBIN}/pip install tox

--- a/.meta.toml
+++ b/.meta.toml
@@ -9,7 +9,7 @@ with-appveyor = true
 with-windows = false
 with-pypy = true
 with-sphinx-doctests = false
-with-future-python = false
+with-future-python = true
 with-macos = false
 
 [tox]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 3.3 (unreleased)
 ================
 
-- Nothing changed yet.
+- Add preliminary support for Python 3.13 as of 3.13a5.
 
 
 3.2 (2024-02-16)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 3.3 (unreleased)
 ================
 
-- Remove premature support for Python 3.13.
+- Nothing changed yet.
 
 
 3.2 (2024-02-16)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,9 @@ environment:
     - python: 310-x64
     - python: 311-x64
     - python: 312-x64
+    # `multibuild` cannot install non-final versions as they are not on
+    # ftp.python.org, so we skip Python 3.13 until its final release:
+    # - python: 313-x64
 
 install:
   - "SET PYTHONVERSION=%PYTHON%"

--- a/src/zodbpickle/_pickle_33.c
+++ b/src/zodbpickle/_pickle_33.c
@@ -15,15 +15,37 @@ PyDoc_STRVAR(pickle_module_doc,
 #endif
 
 #if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_SIZE) /* 3.9.0a4 */
+
 PYCAPI_COMPAT_STATIC_INLINE(void)
 _Py_SET_SIZE(PyVarObject *ob, Py_ssize_t size)
 {
     ob->ob_size = size;
 }
+
 #define Py_SET_SIZE(ob, size) _Py_SET_SIZE((PyVarObject*)(ob), size)
+
+#endif
+
+#if (PY_VERSION_HEX >= 0x30D00A5) /* 3.13.0a5 */
+
+/**
+ * In 3.13a5 ``_PyLong_AsByteArray`` got a new ``with_exceptions`` argument.
+ * See https://github.com/python/cpython/commit/7861dfd26a41e40c2b4361eb0bb1356b9b4a064b
+ */
+PyAPI_FUNC(int) _PyLong_AsByteArray_compat(PyLongObject* v,
+    unsigned char* bytes, size_t n,
+    int little_endian, int is_signed)
+{
+    return _PyLong_AsByteArray(
+        v, bytes, n, little_endian, is_signed, 1 /* with_exceptions */
+    );
+}
+
+#define _PyLong_AsByteArray(v, bytes, n, little_endian, is_signed) _PyLong_AsByteArray_compat(v, bytes, n, little_endian, is_signed)
 #endif
 
 #if (PY_VERSION_HEX >= 0x30D00A1) /* 3.13.0a1 */
+
 /**
  * In 3.13a1 ``_PyObject_LookupAttrId`` was removed.
  * See https://github.com/python/cpython/commit/579aa89e68a6607398317a50586af781981e89fb
@@ -41,13 +63,16 @@ static int _PyObject_HasAttrId(PyObject* obj, void* id)
     Py_XDECREF(attr_val);
     return result;
 }
+
 /*
 * This declaration was moved to the internal API only accessible for building
 * CPython itself. But the implementation is still in `Objects/longobject.c` and
 * Pythons own `Modules/_pickle.c` still uses it.
 */
 PyAPI_FUNC(size_t) _PyLong_NumBits(PyObject *v);
+
 #elif (PY_VERSION_HEX >= 0x30A00B1) /* 3.10.0b1 */
+
 /**
  * The function ``_PyObject_LookupAttrId`` function replaces the combo of
  * ``_PyObject_HasAttrId`` followed by ``_PyObject_GetAttrId``; our code isn't
@@ -62,6 +87,7 @@ static int _PyObject_HasAttrId(PyObject* obj, void* id)
     Py_XDECREF(attr_val);
     return result;
 }
+
 #endif
 
 #if (PY_VERSION_HEX < 0x30B00A7) /* 3.11.0a7 */

--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,13 @@ envlist =
     py310,py310-pure
     py311,py311-pure
     py312,py312-pure
+    py313,py313-pure
     pypy3
     coverage
 
 [testenv]
 usedevelop = true
+pip_pre = py313: true
 deps =
 setenv =
     pure: PURE_PYTHON=1


### PR DESCRIPTION
Again we get errors while compiling the C code:

```
gcc -pthread -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -O3 -pipe -fPIC -I/opt/hostedtoolcache/Python/3.13.0-alpha.4/x64/include/python3.13 -c src/zodbpickle/_pickle_33.c -o build/temp.linux-x86_64-cpython-313/src/zodbpickle/_pickle_33.o
src/zodbpickle/_pickle_[33](https://github.com/zopefoundation/zodbpickle/actions/runs/8200508876/job/22427408652?pr=83#step:10:34).c: In function ‘save_long’:
src/zodbpickle/_pickle_33.c:1668:13: error: too few arguments to function ‘_PyLong_AsByteArray’
 1668 |         i = _PyLong_AsByteArray((PyLongObject *)obj,
      |             ^~~~~~~~~~~~~~~~~~~
In file included from /opt/hostedtoolcache/Python/3.13.0-alpha.4/x64/include/python3.13/longobject.h:90,
                 from /opt/hostedtoolcache/Python/3.13.0-alpha.4/x64/include/python3.13/Python.h:66,
                 from src/zodbpickle/_pickle_33.c:1:
/opt/hostedtoolcache/Python/3.13.0-alpha.4/x64/include/python3.13/cpython/longobject.h:85:17: note: declared here
   85 | PyAPI_FUNC(int) _PyLong_AsByteArray(PyLongObject* v,
      |                 ^~~~~~~~~~~~~~~~~~~
src/zodbpickle/_pickle_33.c: In function ‘save_float’:
src/zodbpickle/_pickle_33.c:17[40](https://github.com/zopefoundation/zodbpickle/actions/runs/8200508876/job/22427408652?pr=83#step:10:41):30: warning: pointer targets in passing argument 2 of ‘PyFloat_Pack8’ differ in signedness [-Wpointer-sign]
 1740 |         if (PyFloat_Pack8(x, (unsigned char *)&pdata[1], 0) < 0)
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |                              |
      |                              unsigned char *
In file included from /opt/hostedtoolcache/Python/3.13.0-alpha.4/x64/include/python3.13/floatobject.h:47,
                 from /opt/hostedtoolcache/Python/3.13.0-alpha.4/x64/include/python3.13/Python.h:69,
                 from src/zodbpickle/_pickle_33.c:1:
/opt/hostedtoolcache/Python/3.13.0-alpha.4/x64/include/python3.13/cpython/floatobject.h:23:47: note: expected ‘char *’ but argument is of type ‘unsigned char *’
   23 | PyAPI_FUNC(int) PyFloat_Pack8(double x, char *p, int le);
      |                                         ~~~~~~^
src/zodbpickle/_pickle_33.c: In function ‘load_binfloat’:
src/zodbpickle/_pickle_33.c:[42](https://github.com/zopefoundation/zodbpickle/actions/runs/8200508876/job/22427408652?pr=83#step:10:43)92:25: warning: pointer targets in passing argument 1 of ‘PyFloat_Unpack8’ differ in signedness [-Wpointer-sign]
 4292 |     x = PyFloat_Unpack8((unsigned char *)s, 0);
      |                         ^~~~~~~~~~~~~~~~~~
      |                         |
      |                         unsigned char *
In file included from /opt/hostedtoolcache/Python/3.13.0-alpha.4/x64/include/python3.13/floatobject.h:[47](https://github.com/zopefoundation/zodbpickle/actions/runs/8200508876/job/22427408652?pr=83#step:10:48),
                 from /opt/hostedtoolcache/Python/3.13.0-alpha.4/x64/include/python3.13/Python.h:69,
                 from src/zodbpickle/_pickle_33.c:1:
/opt/hostedtoolcache/Python/3.13.0-alpha.4/x64/include/python3.13/cpython/floatobject.h:27:[48](https://github.com/zopefoundation/zodbpickle/actions/runs/8200508876/job/22427408652?pr=83#step:10:49): note: expected ‘const char *’ but argument is of type ‘unsigned char *’
   27 | PyAPI_FUNC(double) PyFloat_Unpack8(const char *p, int le);
      |                                    ~~~~~~~~~~~~^
error: command '/usr/bin/gcc' failed with exit code 1
```