### PR TITLE
fix: pure python build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -602,7 +602,7 @@ jobs:
       - name: Restore pip cache permissions
         run: sudo chown -R $(whoami) ${{ steps.pip-cache-default.outputs.dir }}
       - name: Prevent publishing wheels for unreleased Python versions
-        run: VER=$(echo '3.13' | tr -d .) && rm -f /io/wheelhouse/*-cp${VER}*.whl
+        run: VER=$(echo '3.13' | tr -d .) && ls -al /io/wheelhouse && rm -f /io/wheelhouse/*-cp${VER}*.whl && ls -al /io/wheelhouse
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: >

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -602,7 +602,7 @@ jobs:
       - name: Restore pip cache permissions
         run: sudo chown -R $(whoami) ${{ steps.pip-cache-default.outputs.dir }}
       - name: Prevent publishing wheels for unreleased Python versions
-        run: VER=$(echo '3.13' | tr -d .) && rm -f wheelhouse/*-cp${VER}*.whl
+        run: VER=$(echo '3.13' | tr -d .) && rm -f /io/wheelhouse/*-cp${VER}*.whl
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: >

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -602,7 +602,7 @@ jobs:
       - name: Restore pip cache permissions
         run: sudo chown -R $(whoami) ${{ steps.pip-cache-default.outputs.dir }}
       - name: Prevent publishing wheels for unreleased Python versions
-        run: VER=$(echo '3.13' | tr -d .) && ls -al /io/wheelhouse && rm -f /io/wheelhouse/*-cp${VER}*.whl && ls -al /io/wheelhouse
+        run: VER=$(echo '3.13' | tr -d .) && ls -al wheelhouse && rm -f /io/wheelhouse/*-cp${VER}*.whl && ls -al wheelhouse
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: >

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -602,7 +602,7 @@ jobs:
       - name: Restore pip cache permissions
         run: sudo chown -R $(whoami) ${{ steps.pip-cache-default.outputs.dir }}
       - name: Prevent publishing wheels for unreleased Python versions
-        run: VER=$(echo '3.13') | tr -d .) && rm -f wheelhouse/*-cp${VER}*.whl
+        run: VER=$(echo '3.13') | tr -d ".)" && rm -f wheelhouse/*-cp${VER}*.whl
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: >

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -602,7 +602,7 @@ jobs:
       - name: Restore pip cache permissions
         run: sudo chown -R $(whoami) ${{ steps.pip-cache-default.outputs.dir }}
       - name: Prevent publishing wheels for unreleased Python versions
-        run: VER=$(echo '3.13' | tr -d .) && ls -al wheelhouse && rm -f /io/wheelhouse/*-cp${VER}*.whl && ls -al wheelhouse
+        run: VER=$(echo '3.13' | tr -d .) && ls -al wheelhouse && sudo rm -f wheelhouse/*-cp${VER}*.whl && ls -al wheelhouse
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: >

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -384,7 +384,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.11"]
         os: [ubuntu-latest]
 
     steps:
@@ -452,7 +452,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.11"]
         os: [ubuntu-latest]
 
     steps:
@@ -520,7 +520,7 @@ jobs:
     # We use a regular Python matrix entry to share as much code as possible.
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.11"]
         image: [manylinux2014_x86_64, manylinux2014_i686, manylinux2014_aarch64]
 
     steps:
@@ -601,6 +601,8 @@ jobs:
           name: manylinux_${{ matrix.image }}_wheels.zip
       - name: Restore pip cache permissions
         run: sudo chown -R $(whoami) ${{ steps.pip-cache-default.outputs.dir }}
+      - name: Prevent publishing wheels for unreleased Python versions
+        run: VER=$(echo '3.13') | tr -d .) && rm -f wheelhouse/*-cp${VER}*.whl
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: >

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -602,7 +602,7 @@ jobs:
       - name: Restore pip cache permissions
         run: sudo chown -R $(whoami) ${{ steps.pip-cache-default.outputs.dir }}
       - name: Prevent publishing wheels for unreleased Python versions
-        run: VER=$(echo '3.13') | tr -d ".)" && rm -f wheelhouse/*-cp${VER}*.whl
+        run: VER=$(echo '3.13' | tr -d .) && rm -f wheelhouse/*-cp${VER}*.whl
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: >

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "b4846e99"
+commit-id = "c412f00f"
 
 [python]
 with-appveyor = true

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ py_impl = getattr(platform, 'python_implementation', lambda: None)
 is_pypy = py_impl() == 'PyPy'
 is_jython = py_impl() == 'Jython'
 is_pure = int(os.environ.get('PURE_PYTHON', '0'))
-if is_pypy or is_jython:
+if is_pure or is_pypy or is_jython:
     ext_modules = []
 else:
     ext_modules = [Extension(name='zodbpickle._pickle',

--- a/src/zodbpickle/fastpickle.py
+++ b/src/zodbpickle/fastpickle.py
@@ -17,6 +17,7 @@ So this is a rare case where 'import *' is exactly the right thing to do.
 
 
 import sys
+import warnings
 
 from .pickle_3 import *
 
@@ -26,4 +27,7 @@ del sys.modules['zodbpickle.pickle_3']
 
 # isort: off
 # also make sure that we really have the fast version
-from ._pickle import *  # noqa: E402 module level import not at top of file
+if is_pure:  # noqa: F405
+    warnings.warn("fastpickle imported under 'PURE_PYTHON' environment")
+else:
+    from ._pickle import *  # noqa: E402 module level import not at top of file

--- a/src/zodbpickle/pickle_3.py
+++ b/src/zodbpickle/pickle_3.py
@@ -26,6 +26,7 @@ Misc variables:
 import codecs
 import io
 import marshal
+import os
 import re
 import struct
 import sys
@@ -41,6 +42,8 @@ import _compat_pickle
 
 __all__ = ["PickleError", "PicklingError", "UnpicklingError", "Pickler",
            "Unpickler", "dump", "dumps", "load", "loads"]
+
+is_pure = int(os.environ.get('PURE_PYTHON', '0'))
 
 # Shortcut for use in isinstance testing
 bytes_types = (bytes, bytearray)
@@ -1506,11 +1509,15 @@ def _loads(s, *, fix_imports=True, encoding="ASCII", errors="strict"):
 
 
 # Use the faster _pickle if possible
-try:
-    from zodbpickle._pickle import *
-except ImportError:
+if is_pure:
     Pickler, Unpickler = _Pickler, _Unpickler
     dump, dumps, load, loads = _dump, _dumps, _load, _loads
+else:
+    try:
+        from zodbpickle._pickle import *
+    except ImportError:
+        Pickler, Unpickler = _Pickler, _Unpickler
+        dump, dumps, load, loads = _dump, _dumps, _load, _loads
 
 # Doctest
 

--- a/src/zodbpickle/tests/pickle_3_tests.py
+++ b/src/zodbpickle/tests/pickle_3_tests.py
@@ -18,10 +18,14 @@ from .pickletester_3 import AbstractPickleTests
 from .pickletester_3 import BigmemPickleTests
 
 
-try:
-    from zodbpickle import _pickle
-    has_c_implementation = not _is_pypy and not _is_pure
-except ImportError:
+if not _is_pypy and not _is_pure:
+    try:
+        from zodbpickle import _pickle
+    except ImportError:
+        has_c_implementation = False
+    else:
+        has_c_implementation = True
+else:
     has_c_implementation = False
 
 

--- a/src/zodbpickle/tests/test_pickle.py
+++ b/src/zodbpickle/tests/test_pickle.py
@@ -2,15 +2,17 @@ import sys
 import types
 import unittest
 
+from . import _is_pure
 from . import _is_pypy
 
 
-if _is_pypy:
+if _is_pure or _is_pypy:
     function_type = types.FunctionType
 else:
     function_type = types.BuiltinFunctionType
 del sys
 del _is_pypy
+del _is_pure
 
 
 class TestImportability(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ envlist =
     coverage
 
 [testenv]
-usedevelop = true
 pip_pre = py313: true
 deps =
     setuptools < 69
@@ -42,6 +41,7 @@ commands =
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
     coverage html -i
     coverage report -i -m --fail-under=63
+
 [testenv:release-check]
 description = ensure that the distribution is ready to release
 basepython = python3


### PR DESCRIPTION
- Drops 'usedevelop = true' in tox environ (see https://github.com/zopefoundation/meta/pull/257).
- Suppresses building the C extension if `PURE_PYTHON=1` is set in the environment.
- Fixes tests which relied on being able to import the C extension even in a "pure" environment.

Note that wheels built with `PURE_PYTHON=1` set will be 'py3-none-any` wheels.  I'm not sure whether this PR should update the GHA workflow to cause such a wheel to be built.