### PR TITLE
Fix `NameError` which occurred when importing `zodbpickle.fastpickle`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 4.2 (unreleased)
 ================
 
+- Fix ``NameError`` which occurred when importing ``zodbpickle.fastpickle``.
 
 4.1 (2024-09-17)
 ================

--- a/src/zodbpickle/pickle_3.py
+++ b/src/zodbpickle/pickle_3.py
@@ -41,7 +41,7 @@ import _compat_pickle
 
 
 __all__ = ["PickleError", "PicklingError", "UnpicklingError", "Pickler",
-           "Unpickler", "dump", "dumps", "load", "loads"]
+           "Unpickler", "dump", "dumps", "load", "loads", "is_pure"]
 
 is_pure = int(os.environ.get('PURE_PYTHON', '0'))
 


### PR DESCRIPTION
`is_pure` is expected to be imported by `from .pickle_3 import *` in `zodbpickle.fastpickle`.

Detected via broken test in `zc.zodbdgc`: https://github.com/zopefoundation/zc.zodbdgc/actions/runs/10980944943/job/30487366480