### PR TITLE
Fix compilation on free-threaded Python 3.14t

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,8 +100,8 @@ jobs:
           - os: macos-latest
             python-version: "pypy-3.11"
         include:
-          - os: ubuntu-latest
-            python-version: "3.14t"
+          - python-version: "3.14t"
+            os: ubuntu-latest
 
     steps:
       - name: checkout
@@ -259,8 +259,8 @@ jobs:
           - os: macos-latest
             python-version: "pypy-3.11"
         include:
-          - os: ubuntu-latest
-            python-version: "3.14t"
+          - python-version: "3.14t"
+            os: ubuntu-latest
 
     steps:
       - name: checkout
@@ -637,10 +637,10 @@ jobs:
           # PyPy wheels shouldn't be uploaded, remove them if present
           find dist/ -name "*pypy*" -type f -delete || true
           find dist/ -name "*none-any*" -type f -delete || true
-          # Wheels for the no-yet-supported future Python version need to go
+          # Wheels for the not-yet-supported future Python version need to go
           find dist/ -name "*3.15*" -type f -delete || true
           find dist/ -name "*cp315*" -type f -delete || true
-          # Free-threaded wheels are not published separately
+          # Free-threaded Python wheels should not be published yet
           find dist/ -name "*cp314t*" -type f -delete || true
           # For Linux, we only want the manylinux wheels
           find dist/ -name "*linux_x86_64*" -type f -delete || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,6 +99,9 @@ jobs:
         exclude:
           - os: macos-latest
             python-version: "pypy-3.11"
+        include:
+          - os: ubuntu-latest
+            python-version: "3.14t"
 
     steps:
       - name: checkout
@@ -255,6 +258,9 @@ jobs:
         exclude:
           - os: macos-latest
             python-version: "pypy-3.11"
+        include:
+          - os: ubuntu-latest
+            python-version: "3.14t"
 
     steps:
       - name: checkout
@@ -634,6 +640,8 @@ jobs:
           # Wheels for the no-yet-supported future Python version need to go
           find dist/ -name "*3.15*" -type f -delete || true
           find dist/ -name "*cp315*" -type f -delete || true
+          # Free-threaded wheels are not published separately
+          find dist/ -name "*cp314t*" -type f -delete || true
           # For Linux, we only want the manylinux wheels
           find dist/ -name "*linux_x86_64*" -type f -delete || true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -640,8 +640,6 @@ jobs:
           # Wheels for the not-yet-supported future Python version need to go
           find dist/ -name "*3.15*" -type f -delete || true
           find dist/ -name "*cp315*" -type f -delete || true
-          # Free-threaded Python wheels should not be published yet
-          find dist/ -name "*cp314t*" -type f -delete || true
           # For Linux, we only want the manylinux wheels
           find dist/ -name "*linux_x86_64*" -type f -delete || true
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ lib64
 log/
 parts/
 pyvenv.cfg
+share/
 testing.log
 var/

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/c-code
 [meta]
 template = "c-code"
-commit-id = "f62d8bab"
+commit-id = "da74ecd0"
 
 [python]
 with-windows = true
@@ -11,12 +11,11 @@ with-sphinx-doctests = false
 with-future-python = true
 with-macos = false
 with-docs = true
+with-free-threaded-python = true
 
 [tox]
 use-flake8 = true
-additional-envlist = [
-    "py314t,py314t-pure",
-]
+additional-envlist = []
 
 [coverage]
 fail-under = 63

--- a/.meta.toml
+++ b/.meta.toml
@@ -14,6 +14,9 @@ with-docs = true
 
 [tox]
 use-flake8 = true
+additional-envlist = [
+    "py314t,py314t-pure",
+]
 
 [coverage]
 fail-under = 63

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/c-code
 [meta]
 template = "c-code"
-commit-id = "da74ecd0"
+commit-id = "2dc4f53b"
 
 [python]
 with-windows = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     - id: autopep8
       args: [--in-place, --aggressive, --aggressive]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.0
+    rev: v3.21.2
     hooks:
     - id: pyupgrade
       args: [--py310-plus]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Change log
 4.4 (unreleased)
 ----------------
 
+- Fix compilation on free-threaded Python 3.14t: use ``Py_REFCNT()`` macro
+  instead of direct ``ob_refcnt`` struct access, and ``Py_TYPE()`` instead of
+  direct ``ob_type`` struct access.
+
+- Add CI testing for free-threaded Python 3.14t (Linux).
+
 
 4.3 (2025-11-20)
 ----------------

--- a/src/zodbpickle/_pickle_33.c
+++ b/src/zodbpickle/_pickle_33.c
@@ -717,7 +717,7 @@ PyMemoTable_Set(PyMemoTable *self, PyObject *key, Py_ssize_t value)
     } while (0)
 
 #define FREE_ARG_TUP(self) do {                 \
-        if ((self)->arg->ob_refcnt > 1)         \
+        if (Py_REFCNT((self)->arg) > 1)         \
             Py_CLEAR((self)->arg);              \
     } while (0)
 
@@ -1525,7 +1525,7 @@ fast_save_enter(PicklerObject *self, PyObject *obj)
             PyErr_Format(PyExc_ValueError,
                          "fast mode: can't pickle cyclic objects "
                          "including object type %.200s at %p",
-                         obj->ob_type->tp_name, obj);
+                         Py_TYPE(obj)->tp_name, obj);
             self->fast_nesting = -1;
             return 0;
         }

--- a/tox.ini
+++ b/tox.ini
@@ -11,10 +11,10 @@ envlist =
     py313,py313-pure
     py314,py314-pure
     py315,py315-pure
+    py314t,py314t-pure
     pypy3
     docs
     coverage
-    py314t,py314t-pure
 
 [testenv]
 pip_pre = py315: true

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ envlist =
     pypy3
     docs
     coverage
+    py314t,py314t-pure
 
 [testenv]
 pip_pre = py315: true
@@ -61,7 +62,7 @@ deps =
 commands_pre =
 commands =
     check-manifest
-    check-python-versions --only pyproject.toml,setup.py,tox.ini,.github/workflows/tests.yml
+    check-python-versions --only pyproject.toml,setup.py,tox.ini
     python -m build --sdist --no-isolation
     twine check dist/*
 


### PR DESCRIPTION
## Summary

- Replace \`ob_refcnt\` direct access with \`Py_REFCNT()\` macro in \`FREE_ARG_TUP\` macro (line 720)
- Replace \`obj->ob_type->tp_name\` with \`Py_TYPE(obj)->tp_name\` (line 1528)
- Add 3.14t to CI matrix and tox envlist

Tested locally: compiles and all tests pass on both Python 3.14 and 3.14t.

Refs #106